### PR TITLE
add luci-lib-ipkg and luci-theme-argon to depends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PKG_MAINTAINER:=jerrykuku <jerrykuku@qq.com>
 
 LUCI_TITLE:=LuCI page for Argon Config
 LUCI_PKGARCH:=all
-LUCI_DEPENDS:=+luci-compat
+LUCI_DEPENDS:=+luci-compat +luci-lib-ipkg +luci-theme-argon
 
 define Package/$(PKG_NAME)/conffiles
 /etc/config/argon


### PR DESCRIPTION
add luci-lib-ipkg and luci-theme-argon to depends

luci-lib-ipkg fixes https://github.com/jerrykuku/luci-theme-argon/issues/151
luci-theme-argon because this program is designed to work upon it.