### PR TITLE
update github action stuff

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,14 +28,14 @@ jobs:
         docker pull openwrt/sdk
         docker run --rm -u root -v "$(pwd)"/bin/:/home/build/openwrt/bin -v ${{ github.workspace }}/.github/workflows:/home/build/workflows openwrt/sdk /bin/sh /home/build/workflows/build.sh
     - name: Upload app
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: luci-app-argon-config
         path: ./bin/packages/x86_64/base/*argon-config*
         if-no-files-found: error
     - name: Upload Log
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: buildlog
         path: bin/logs.tar.xz

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,8 +25,8 @@ jobs:
         cp -rf ./luasrc ./po ./root ./Makefile ./bin/luci-app-argon-config
     - name: Docker Build
       run: |
-        docker pull openwrtorg/sdk:x86-64-21.02-SNAPSHOT
-        docker run --rm -u root -v "$(pwd)"/bin/:/home/build/openwrt/bin -v ${{ github.workspace }}/.github/workflows:/home/build/workflows openwrtorg/sdk:x86-64-21.02-SNAPSHOT /bin/sh /home/build/workflows/build.sh
+        docker pull openwrt/sdk
+        docker run --rm -u root -v "$(pwd)"/bin/:/home/build/openwrt/bin -v ${{ github.workspace }}/.github/workflows:/home/build/workflows openwrt/sdk /bin/sh /home/build/workflows/build.sh
     - name: Upload app
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
         cp -rf ./luasrc ./po ./root ./Makefile ./bin/luci-app-argon-config
     - name: Docker Build
       run: |
-        docker pull openwrtorg/sdk:x86-64-21.02-SNAPSHOT
-        docker run --rm -u root -v "$(pwd)"/bin/:/home/build/openwrt/bin -v ${{ github.workspace }}/.github/workflows:/home/build/workflows openwrtorg/sdk:x86-64-21.02-SNAPSHOT /bin/sh /home/build/workflows/build.sh
+        docker pull openwrt/sdk
+        docker run --rm -u root -v "$(pwd)"/bin/:/home/build/openwrt/bin -v ${{ github.workspace }}/.github/workflows:/home/build/workflows openwrt/sdk /bin/sh /home/build/workflows/build.sh
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         hub release create -p "${assets[@]}" -m "$tag_name" "$tag_name"
     - name: Upload Log
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: buildlog
         path: bin/logs.tar.xz


### PR DESCRIPTION
1. `openwrt` changed their `sdk` repo from `openwrtorg/sdk` to `openwrt/sdk`.
2. use `latest` sdk image version instead of a specific version, so it'll probably always build against the latest openwrt sdk image.
3. `actions/upload-artifact@v2` is deprecated, update to `@v3`
