### PR TITLE
fix compatibility issue with openwrt 21.02-

### DIFF
--- a/htdocs/luci-static/resources/view/argon-config.js
+++ b/htdocs/luci-static/resources/view/argon-config.js
@@ -6,9 +6,9 @@
 'require ui';
 'require view';
 
-var callSystemInfo = rpc.declare({
-	object: 'system',
-	method: 'info'
+var callAvailSpace = rpc.declare({
+	object: 'luci.argon',
+	method: 'avail'
 });
 
 var callRemoveArgon = rpc.declare({
@@ -34,7 +34,7 @@ return view.extend({
 	load: function() {
 		return Promise.all([
 			uci.load('argon'),
-			L.resolveDefault(callSystemInfo(), {}),
+			L.resolveDefault(callAvailSpace(), {}),
 			L.resolveDefault(fs.list(bg_path), {})
 		]);
 	},
@@ -120,7 +120,7 @@ return view.extend({
 		}
 
 		s = m.section(form.TypedSection, null, _('Upload background (available space: %1024.2mB)')
-			.format(data[1].root.avail * 1024),
+			.format(data[1].avail * 1024),
 			_('You can upload files such as gif/jpg/mp4/png/webm/webp files, to change the login page background.'));
 		s.addremove = false;
 		s.anonymous = true;

--- a/root/etc/config/argon
+++ b/root/etc/config/argon
@@ -1,10 +1,10 @@
 config global
 	option primary '#5e72e4'
 	option dark_primary '#483d8b'
-	option blur '0'
-	option blur_dark '0'
-	option transparency '0.3'
-	option transparency_dark '0.3'
+	option blur '10'
+	option blur_dark '10'
+	option transparency '0.5'
+	option transparency_dark '0.5'
 	option mode 'normal'
 	option online_wallpaper 'bing'
 

--- a/root/usr/libexec/rpcd/luci.argon
+++ b/root/usr/libexec/rpcd/luci.argon
@@ -9,6 +9,8 @@ readonly tmp_path="/tmp/argon_background.tmp"
 case "$1" in
 "list")
 	json_init
+	json_add_object "avail"
+	json_close_object
 	json_add_object "remove"
 		json_add_string "filename" "filename"
 	json_close_object
@@ -20,6 +22,12 @@ case "$1" in
 	;;
 "call")
 	case "$2" in
+	"avail")
+		json_init
+		json_add_int "avail" "$(df | grep -E '/$' | awk '{print $4}')"
+		json_dump
+		json_cleanup
+		;;
 	"remove")
 		read -r input
 		json_load "$input"

--- a/root/usr/share/rpcd/acl.d/luci-app-argon-config.json
+++ b/root/usr/share/rpcd/acl.d/luci-app-argon-config.json
@@ -6,8 +6,7 @@
 				"/www/luci-static/argon/background/*": [ "list" ]
 			},
 			"ubus": {
-				"luci.argon": [ "remove", "rename" ],
-				"system": [ "info" ]
+				"luci.argon": [ "avail", "remove", "rename" ]
 			},
 			"uci": [ "argon" ]
 		},


### PR DESCRIPTION
On OpenWrt 21.02 and lower version, "system info" doesn't provide space info, which fails page loading. Let's simply add a new func to rpcd script to fetch available space.

While at it, revert unnecessary changes to argon uci config.

Fixes: 5b8057beda83e9 ("refactor: rewritten in JS")